### PR TITLE
adjust block/latest respose

### DIFF
--- a/src/native.auth.client.ts
+++ b/src/native.auth.client.ts
@@ -58,8 +58,8 @@ export class NativeAuthClient {
     try {
       const url = `${this.config.apiUrl}/blocks/latest?ttl=${this.config.expirySeconds}&fields=hash`;
       const response = await this.get(url);
-      if (response.data[0].hash !== undefined) {
-          return response.data[0].hash;
+      if (response?.data?.hash !== undefined) {
+          return response.data.hash;
       }
     } catch (error) {}
     return this.getCurrentBlockHashWithApiFallback();


### PR DESCRIPTION
From what I see on the devnet and the testnet, the new endpoint `block/latest` doesn't return an array, so we should fix the response structure here if we want to use it before the fallback. Otherwise, we will get two calls to the API, and fallback will be used anyway.